### PR TITLE
pg:  lookup paths to server utils

### DIFF
--- a/dbenv-pg
+++ b/dbenv-pg
@@ -1,8 +1,36 @@
 #!/bin/bash
 
+# Find a postgres server utilitiy.  We have to do this as some distros do not
+# put the utilities in the default PATH.
+find_util() {
+	local util=$(which $1)
+	if [ -n "${util}" ]; then
+		echo ${util}
+		return
+	fi
+
+	local d="/usr/lib/postgresql"
+	if [ -d "${d}" ] && [ -x "${d}/bin/${util}" ]; then
+		echo "${d}/bin/${util}"
+		return
+	fi
+
+	for d in $(echo /usr/lib/postgresql* | sort); do
+		if [ -x "${d}/bin/${util}" ]; then
+			echo "${d}/bin/${util}"
+			return
+		fi
+	done
+}
+
+PSQL=$(find_util psql)
+INITDB=$(find_util initdb)
+CREATEDB=$(find_util createdb)
+PG_CTL=$(find_util pg_ctl)
+
 have_database() {
 	! server_running || return 1;
-	psql -U ${USER} -h ${HOST} -p ${PORT} \
+	${PSQL} -U ${USER} -h ${HOST} -p ${PORT} \
 		| awk '{print $1}' \
 		| grep -qw ${DBNAME}
 }
@@ -30,11 +58,11 @@ _server_running() {
 
 _write_server_configs() {
 	info "Running initdb"
-	initdb -D ${B}/data -U ${USER} -A trust > ${B}/initdb.log
+	${INITDB} -D ${B}/data -U ${USER} -A trust > ${B}/initdb.log
 }
 
 _start_server() {
-	pg_ctl start -D ${B}/data -l ${B}/log  -w -o "-k ${B}/tmp -p ${PORT}"
+	${PG_CTL} start -D ${B}/data -l ${B}/log  -w -o "-k ${B}/tmp -p ${PORT}"
 	r=$?
 
 	if [ ${r} -ne 0 ]; then
@@ -43,7 +71,7 @@ _start_server() {
 	fi
 
 	if ! have_database; then
-		createdb -h ${HOST} -U ${USER} -p ${PORT} ${DBNAME}
+		${CREATEDB} -h ${HOST} -U ${USER} -p ${PORT} ${DBNAME}
 		r=${?}
 
 		if [ ${r} -ne 0 ]; then
@@ -57,7 +85,7 @@ _start_server() {
 _stop_server() {
 	local pid=$(head -n 1 ${B}/data/postmaster.pid)
 
-	pg_ctl stop -D ${B}/data
+	${PG_CTL} stop -D ${B}/data
 	if [ $? -ne 0 ]; then
 		err "Failed to stop server"
 		return 1
@@ -67,7 +95,7 @@ _stop_server() {
 }
 
 _shell() {
-	psql -U ${USER} -h ${HOST} -d ${DBNAME} -p ${PORT} ${@}
+	${PSQL} -U ${USER} -h ${HOST} -d ${DBNAME} -p ${PORT} ${@}
 }
 
 _url() {


### PR DESCRIPTION
Some distros don't put the server utils like initdb or pg_ctl in the
default PATH.  Attempt to look them up from PATH to symlinks to the
highest version of postgres available.

@igorfala  Can you check if this works for you?