### PR TITLE
Three-platform compatibility pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,5 @@ uninstall:
 test:
 	@for driver in $(DRIVERS); do \
 		echo Testing $${driver}; \
-		setsid test/test-$${driver}; \
+		test/test-$${driver}; \
 	done;

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BINDIR ?= ~/bin
 DBENV_ROOT ?= ~/.local/dbenv
 
 DRIVERDIR = $(DBENV_ROOT)/drivers
-DRIVERS=pg redis
+DRIVERS ?= pg redis
 
 .PHONY: test
 

--- a/dbenv
+++ b/dbenv
@@ -45,7 +45,6 @@ get_port() {
 		return
 	fi
 
-	local host=${1}
 	local cmd
 
 	cmd+="import socket;"
@@ -108,8 +107,6 @@ server_running() {
 }
 
 init_server() {
-	local r
-
 	server_initialized && return
 
 	_write_server_configs
@@ -124,8 +121,6 @@ init_server() {
 }
 
 start_server() {
-	local r
-
 	if ! server_initialized; then
 		init_server || return 1
 	fi

--- a/dbenv
+++ b/dbenv
@@ -42,6 +42,7 @@ warn() { echo -e "\e[33m*\e[0m $*"; }
 get_port() {
 	if server_running; then
 		_get_port_from_running_db
+		return
 	fi
 
 	local host=${1}

--- a/dbenv
+++ b/dbenv
@@ -219,7 +219,8 @@ _source_driver() {
 }
 
 if [ -n "${DBENV_ROOT}" ]; then
-	DBENV_ROOT=$(readlink -f ${DBENV_ROOT})
+	[ -d "${DBENV_ROOT}" ] || mkdir -p "${DBENV_ROOT}"
+	DBENV_ROOT=$(realpath "${DBENV_ROOT}")
 fi
 
 DRIVER=$(basename ${0})
@@ -243,7 +244,7 @@ while [ $# -ne 0 ]; do
 		-b|--base-dir)
 			shift;
 			mkdir -p ${1} &> /dev/null
-			B=$(readlink -f ${1})
+			B=$(realpath ${1})
 			;;
 		-d|--db)
 			shift;
@@ -253,7 +254,7 @@ while [ $# -ne 0 ]; do
 			force=true
 			;;
 		-I|--initialize)
-			B=$(readlink -f $(pwd))/${DBDATA}
+			B=$(pwd -P)/${DBDATA}
 			mkdir -p ${B} &> /dev/null
 			;;
 		-h)

--- a/dbenv
+++ b/dbenv
@@ -45,20 +45,17 @@ get_port() {
 		return
 	fi
 
-	local cmd
+	local py
+	for py in python3 python3.5 python2 python2.7 python; do
+		which $py 1>/dev/null && break
+	done
 
-	cmd+="import socket;"
-	cmd+="s = socket.socket(socket.AF_INET, socket.SOCK_STREAM);"
-	cmd+="s.bind(('127.0.0.1', 0));"
-	cmd+="print(s.getsockname()[1]);"
-
-	if [ -n "$(which python)" ]; then
-		echo ${cmd} | python
-	elif [ -n "$(which python3)" ]; then
-		echo ${cmd} | python3
-	else
-		echo ${cmd} | python2
-	fi
+	$py <<-EOF
+		import socket
+		s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		s.bind(('127.0.0.1', 0))
+		print(s.getsockname()[1])
+	EOF
 }
 
 init() {

--- a/dbenv
+++ b/dbenv
@@ -35,9 +35,9 @@ usage() {
 	EOF
 }
 
-err() { echo -e "\e[31m*\e[0m $*"; }
-info() { echo -e "\e[32m*\e[0m $*"; }
-warn() { echo -e "\e[33m*\e[0m $*"; }
+err() { echo $'\e[31m*\e[0m' "$*"; }
+info() { echo $'\e[32m*\e[0m' "$*"; }
+warn() { echo $'\e[33m*\e[0m' "$*"; }
 
 get_port() {
 	if server_running; then

--- a/dbenv
+++ b/dbenv
@@ -154,7 +154,7 @@ shell() {
 		start_server || return 1
 	fi
 
-	_shell ${@}
+	_shell "${@}"
 }
 
 
@@ -258,7 +258,7 @@ while [ $# -ne 0 ]; do
 			if [ -z "${action}" ]; then
 				action=${1}
 			else
-				extra+=(${1})
+				extra+=("${1}")
 			fi
 			;;
 	esac
@@ -284,7 +284,7 @@ case ${action} in
 		stop_server
 		;;
 	shell)
-		shell ${extra[@]}
+		shell "${extra[@]}"
 		;;
 	clean)
 		server_running && stop_server

--- a/readme.md
+++ b/readme.md
@@ -23,3 +23,13 @@ ACTION:
 
 EXTRA ARGUMENTS are passed when using the 'shell' action and are otherwise ignored.
 ```
+
+Mac OS X
+--------
+
+dbenv relies on GNU realpath utility. On Mac OS X, you have to install
+coreutils package, e.g. via homebrew:
+
+```
+brew install coreutils
+```

--- a/test/base.sh
+++ b/test/base.sh
@@ -12,9 +12,9 @@ fi
 
 export R=$(realpath $(dirname $0/)/../)
 export DBENV_ROOT=${R}
-export TMPDIR=$(readlink -f $(dirname $0))
+export TMPDIR=$(realpath $(dirname $0))
 T=$(mktemp -d ${TMPDIR}/tmpXXX)
-FULL_PATH=$(readlink -f $0)
+FULL_PATH=$(realpath $0)
 
 cleanup() {
     if [ -d ${T} ]; then

--- a/test/base.sh
+++ b/test/base.sh
@@ -2,7 +2,15 @@
 
 set -o pipefail
 
-export R=$(readlink -f $(dirname $0/)/../)
+PGID=$(ps -o pgid -p $$ | tail -1)
+if [ "$PGID" != "$$" ]; then
+	which setsid &>/dev/null && exec setsid "$0" "$@"
+	which script &>/dev/null && exec script -q /dev/null "$0" "$@"
+	echo "ERROR: failed to become group leader"
+	exit 1
+fi
+
+export R=$(realpath $(dirname $0/)/../)
 export DBENV_ROOT=${R}
 export TMPDIR=$(readlink -f $(dirname $0))
 T=$(mktemp -d ${TMPDIR}/tmpXXX)

--- a/test/test-pg
+++ b/test/test-pg
@@ -39,4 +39,4 @@ test_3_pg() {
     [ ! -d ${T}/dbdir/data ] || die ${LINENO}
 }
 
-source $(dirname $(readlink -f ${0}))/base.sh
+source $(dirname $(realpath ${0}))/base.sh

--- a/test/test-redis
+++ b/test/test-redis
@@ -49,4 +49,4 @@ test_3_redis() {
     [ ! -d ${T}/dbdir/data ] || die ${LINENO}
 }
 
-source $(dirname $(readlink -f ${0}))/base.sh
+source $(dirname $(realpath ${0}))/base.sh


### PR DESCRIPTION
Geez, this was harder than it should have been.

BSD doesn't have `setsid`, but has `script`.
Linux also has `script`, but Linux's `script` can't launch a process.
Mac's bash documents `echo -e`, but doesn't actually do what it says.
Linux's `which` doesn't have `-s`, but BSD does.

Tested on:
* Xubuntu Linux 16.04
* FreeBSD 10 & 11
* Mac OS X 10.11
* Emacs OS
* Windows CE
